### PR TITLE
oe-build: Switch to Ubuntu 18.04 LTS

### DIFF
--- a/oe-build/Dockerfile
+++ b/oe-build/Dockerfile
@@ -1,72 +1,75 @@
-# ettus/buildbot-worker:fedora-25-oe
+# ettus/buildbot-worker:ubuntu-18.04-oe
 
 # please follow docker best practices
 # https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/
 
-FROM        fedora:25
-MAINTAINER  Ettus Research
+FROM        ubuntu:18.04
+LABEL       maintainer="Ettus Research"
 
 # Last build date - this can be updated whenever there are security updates so
 # that everything is rebuilt
-ENV         security_updates_as_of 2017-04-27
+ENV         security_updates_as_of 2020-04-20
 
+# This will make apt-get install without question
+ARG         DEBIAN_FRONTEND=noninteractive
 
 # Install Apache Web Server
-RUN dnf install -y \
+RUN apt-get update && apt-get install -y \
+# yocto base dependencies
+# https://www.yoctoproject.org/docs/3.0.2/ref-manual/ref-manual.html#detailed-supported-distros
     gawk \
-    make \
     wget \
-    tar \
-    bzip2 \
-    gzip \
-    python \
-    unzip \
-    findutils \
-    which \
-    perl \
-    patch \
-    diffutils \
-    diffstat \
-    bc \
-    cpio \
-    file \
     git \
-    cpp \
-    gcc \
-    gcc-c++ \
-    gnupg \
-    glibc-devel \
+    diffstat \
+    unzip \
     texinfo \
+    gcc-multilib \
+    build-essential \
     chrpath \
-    openssl \
-    ccache \
-    perl-Data-Dumper \
-    perl-bignum \
-    perl-Text-ParseWords \
-    perl-Thread-Queue \
-    SDL-devel \
+    socat \
+    cpio \
+    python \
+    python3 \
+    python3-pip \
+    python3-pexpect \
+    xz-utils \
+    debianutils \
+    iputils-ping \
+    python3-git \
+    python3-jinja2 \
+    libegl1-mesa \
+    libsdl1.2-dev \
+    pylint3 \
     xterm \
-    iputils \
+# Other deps
+    bc \
+    curl \
+    gnupg \
+    openssl \
     hostname \
     procps \
+    libc-dev-bin \
+    libssl-dev \
+    locales \
     net-tools \
-    iproute \
+    iproute2 \
     python-pip \
-    python-devel \
+    python-dev \
+    python3-dev \
     python-requests \
-    redhat-rpm-config \
-    openssl-devel \
-    rpm-devel \
+    python3-requests \
     rsync \
     tar \
     tmux \
-    xz \
-    && \
-    dnf clean all
-
+    zip \
+&& rm -rf /var/lib/apt/lists/*
 
 RUN useradd -u 2017 -ms /bin/bash oe-builder
 
+# Set UTF-8 Locale for bitbake
+# See https://wiki.yoctoproject.org/wiki/TipsAndTricks/ResolvingLocaleIssues
+RUN locale-gen en_US.UTF-8
+RUN update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
 RUN echo "export LANG=en_US.utf-8" > /opt/export_LANG.sh
 ENV BASH_ENV=/opt/export_LANG.sh \
     ENV=/opt/export_LANG.sh \


### PR DESCRIPTION
This switches the docker image to Ubuntu 18.04 LTS.
This version was picked because yocto tends to have longer support
for LTS versions of Ubuntu